### PR TITLE
Fix "IgnoreWall is not defined" error in Levels compatibility

### DIFF
--- a/scripts/compatibility/PerceptiveCompatibility.js
+++ b/scripts/compatibility/PerceptiveCompatibility.js
@@ -91,6 +91,6 @@ Hooks.once("init", () => {
 	}
 	
 	if (PerceptiveCompUtils.isactiveModule(cLevels)) {
-		libWrapper.register(cModuleName, "CONFIG.Levels.handlers.SightHandler.shouldIgnoreWall", function(pWrapped, pwall, pcollisiontype, options) {if ((options?.source?.document.documentName == "Token") && IgnoreWall(pwall.document, options?.source?.document)){return true} return pWrapped(pwall, pcollisiontype, options)}, "MIXED");
+		libWrapper.register(cModuleName, "CONFIG.Levels.handlers.SightHandler.shouldIgnoreWall", function(pWrapped, pwall, pcollisiontype, options) {if ((options?.source?.document.documentName == "Token") && PeekingIgnoreWall(pwall.document, options?.source?.document)){return true} return pWrapped(pwall, pcollisiontype, options)}, "MIXED");
 	}
 });


### PR DESCRIPTION
Perceptive was giving me this error on line 94 of `PerceptiveCompatibility.js` when the Levels module was active:

```
Uncaught ReferenceError: IgnoreWall is not defined [Detected 5 packages: perceptive, lib-wrapper, levels, system:pf2e, gm-vision]
```

From what I can tell, `PeekingIgnoreWall` is just a wrapper around `IgnoreWall`, and only the former was imported, so swapping the latter for the former seems to have fixed the issue.